### PR TITLE
fixed addon activation

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -668,6 +668,9 @@ Server.prototype.activatePlugin = function(type) {
 	    	}
     	})
     }
+	else {
+		configuredPlugins = [];
+	}
     
     if (!found) {
 	    // Generate new Entry


### PR DESCRIPTION
When configuredPlugins is undefined you can't push new plugins to it.
You have to init an array first.