### PR TITLE
fixed server shutdown

### DIFF
--- a/lib/ConfigurationServer.js
+++ b/lib/ConfigurationServer.js
@@ -142,7 +142,10 @@ ConfigurationServer.prototype.init = function() {
 
 ConfigurationServer.prototype.shutdown = function() {
 	logger.info("Configuration Server Shutdown");
-	this.server.close();
+	
+	if(this.server != undefined) {
+		this.server.close();
+	}
 }
 
 


### PR DESCRIPTION
I setup a fresh installation of Homematic-virtual-interface but missed
something in the config.
When I wanted to stop the daemon it doesn't worked.
With this fix I could stop the server.