### PR TITLE
Create new user, and run installation/service with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is work in progress.
 Quick Install:
 
  ```
-wget -nv -O- https://raw.githubusercontent.com/thkl/Homematic-Virtual-Interface/master/install.sh | bash -
+wget -nv -O- https://raw.githubusercontent.com/thkl/Homematic-Virtual-Interface/master/install.sh | sudo -E bash -
  ```
 Raspberrymatic:
 

--- a/bin/hmvi.service
+++ b/bin/hmvi.service
@@ -4,8 +4,8 @@ After=multi-user.target
 
 [Service]
 Type=idle
-User=pi
-ExecStart=/home/pi/node_modules/homematic-virtual-interface/bin/hmvi 1> /var/s_hvl.log 2>&1 &
+User=hmvi
+ExecStart=/home/hmvi/node_modules/homematic-virtual-interface/bin/hmvi 1> /var/s_hvl.log 2>&1 &
 Restart=on-failure
 RestartSec=10
 KillMode=process

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,12 @@ sudo test "`dpkg --print-architecture`" == "armhf" || die "This Repos is only fo
 #info "Installing Git"
 #install_package "git"
 
+# create own user
+if [ $(cat /etc/passwd | grep hmvi |wc -l) -eq 0 ];
+then
+    info "Creating new user"
+    useradd -m hmvi
+fi
 
 if [ $(type -P node | grep node|wc -l) -eq 0 ]; 
 then
@@ -48,7 +54,7 @@ then
     tar -xvf node-v4.0.0-linux-armv7l.tar.gz  >/dev/null
     cd node-v4.0.0-linux-armv7l
     sudo cp -R * /usr/local/
-    cd /home/pi
+    cd /home/hmvi
     rm node-v4.0.0-linux-armv7l.tar.gz
     rm node-v4.0.0-linux-armv7l -R
   else
@@ -62,7 +68,7 @@ fi
 
 info "Installing Virtual Layer Software"
 
-cd /home/pi
+cd /home/hmvi
 npm install homematic-virtual-interface
 
 
@@ -70,22 +76,20 @@ whiptail --yesno "Would you like to start the virtual layer at boot by default?"
 RET=$?
 if [ $RET -eq 0 ]; then
 
-    sudo cp /home/pi/node_modules/homematic-virtual-interface/lib/hmvi_npm /etc/init.d/hmvi
+    sudo cp /home/hmvi/node_modules/homematic-virtual-interface/lib/hmvi_npm /etc/init.d/hmvi
   	
   	sudo chmod 755 /etc/init.d/hmvi
 	sudo update-rc.d hmvi defaults
 fi
 
-USER_HOME=$(eval echo ~${SUDO_USER})
-
-if [ ! -d "${USER_HOME}/.hm_virtual_interface" ]; then
+if [ ! -d "/home/hmvi/.hm_virtual_interface" ]; then
 
   CCUIP=$(whiptail --inputbox "Please enter your CCU IP" 20 60 "000.000.000.000" 3>&1 1>&2 2>&3)
 
   echo "build new configuration directory and config"
-  mkdir ${USER_HOME}/.hm_virtual_interface
-  touch ${USER_HOME}/.hm_virtual_interface/config.json
-  echo "{\"ccu_ip\":\"$CCUIP\",\"plugins\":[]}" > ${USER_HOME}/.hm_virtual_interface/config.json
+  mkdir /home/hmvi/.hm_virtual_interface
+  touch /home/hmvi/.hm_virtual_interface/config.json
+  echo "{\"ccu_ip\":\"$CCUIP\",\"plugins\":[]}" > /home/hmvi/.hm_virtual_interface/config.json
 else
   echo "Config is here skipping this step"
 fi

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ fi
 info "Installing Virtual Layer Software"
 
 cd /home/hmvi
-npm install homematic-virtual-interface
+runuser -l hmvi -c "npm install homematic-virtual-interface"
 
 
 whiptail --yesno "Would you like to start the virtual layer at boot by default?" $DEFAULT 20 60 2

--- a/lib/hmvi
+++ b/lib/hmvi
@@ -10,9 +10,9 @@
 ### END INIT INFO
 
 
-dir="/home/pi/Homematic-Virtual-Interface"
+dir="/home/hmvi/Homematic-Virtual-Interface"
 cmd="bin/hmviservice"
-user="pi"
+user="hmvi"
 
 sudo -u "$user" $dir/$cmd $1
 exit 0

--- a/lib/hmvi_npm
+++ b/lib/hmvi_npm
@@ -10,9 +10,9 @@
 ### END INIT INFO
 
 
-dir="/home/pi/node_modules/homematic-virtual-interface"
+dir="/home/hmvi/node_modules/homematic-virtual-interface"
 cmd="bin/hmviservice"
-user="pi"
+user="hmvi"
 
 sudo -u "$user" $dir/$cmd $1
 exit 0

--- a/lib/l_hmvi
+++ b/lib/l_hmvi
@@ -10,9 +10,9 @@
 ### END INIT INFO
 
 
-dir="/home/pi/node_modules/homematic-virtual-interface"
+dir="/home/hmvi/node_modules/homematic-virtual-interface"
 cmd="bin/hmvi"
-user="pi"
+user="hmvi"
 
 name='hvl'
 pid_file="/var/run/$name.pid"


### PR DESCRIPTION
Hi Thomas

i have created a new user, to run the service.
user pi does not exists on other systems like debian/armbian & co

by the way, the installation seems to be broken (on raspbian or other devices)

```
# wget -nv -O- https://raw.githubusercontent.com/thkl/Homematic-Virtual-Interface/master/install.sh | bash -
2018-01-14 18:58:57 URL:https://raw.githubusercontent.com/thkl/Homematic-Virtual-Interface/master/install.sh [2583/2583] -> "-" [1]
node is installed, skipping...
Installing Virtual Layer Software
npm WARN saveError ENOENT: no such file or directory, open '/home/pi/package.json'
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN enoent ENOENT: no such file or directory, open '/home/pi/package.json'
npm WARN pi No description
npm WARN pi No repository field.
npm WARN pi No README data
npm WARN pi No license field.

+ homematic-virtual-interface@0.2.65
added 125 packages in 19.614s
build new configuration directory and config
Done. If there are no error messages you are done.
Start the by typing bin/hmvi
There is an addon file named hvl_addon.tar.gz here. Install this at your ccu as additional software, to setup the ccu to use the virtual layer.
[18:59:25][root@rpi3:~]
# 
```