### PR TITLE
publishUpdateEvent wird ggf. alle <Refresh> Sekunden getriggert

### DIFF
--- a/lib/HomematicChannel.js
+++ b/lib/HomematicChannel.js
@@ -215,7 +215,7 @@ HomematicChannel.prototype.updateValue = function(parameterName,value,notificati
   if (pv!=undefined) {
 	    logger.debug("Channel update Event");
 	  // Only call once !
-	 if ((pv.value != value) || (pv.value==pv.vdefault) || (force)) {
+	 if ((pv.value != value) /*|| (pv.value==pv.vdefault)*/ || (force)) {
 	     pv.value = value;
 		 if (notification!=undefined) {
 			 this.publishUpdateEvent([pv]);

--- a/lib/HomematicChannel.js
+++ b/lib/HomematicChannel.js
@@ -215,7 +215,7 @@ HomematicChannel.prototype.updateValue = function(parameterName,value,notificati
   if (pv!=undefined) {
 	    logger.debug("Channel update Event");
 	  // Only call once !
-	 if ((pv.value != value) /*|| (pv.value==pv.vdefault)*/ || (force)) {
+	 if ((pv.value != value) || (pv.value==pv.vdefault) || (force)) {
 	     pv.value = value;
 		 if (notification!=undefined) {
 			 this.publishUpdateEvent([pv]);


### PR DESCRIPTION
Die Zeile "if ((pv.value != value) || (pv.value==pv.vdefault) || (force))" in
HomematicChannel.prototype.updateValue (HomematicChannel.js) sollte dies eigentlich verhindern. Wenn jedoch pv.vdefault = 0 (AUS) ist, und die Lampe ebenfalls AUS (pv.value = 0) ist, dann stimmt die zweite Bedingung und es wird u.a. bei jedem Hue Refresh ein RPC-Paket abgesetzt. Nicht dramatisch aber aus meiner Sicht unnötiger Traffic.