### PR TITLE
Fix für Windrichtung und Regenstatus

### DIFF
--- a/plugins/WeatherUnderground/WeatherUndergroundPlatform.js
+++ b/plugins/WeatherUnderground/WeatherUndergroundPlatform.js
@@ -125,14 +125,14 @@ WeatherUndergroundPlatform.prototype.fetchWeather = function() {
                                 channel.updateValue('RAIN_COUNTER', 0, true)
                             }
 
-                            if (observation.metric.precipRate > 0) {
+                            if (parseFloat(observation.metric.precipRate) > 0) {
                                 channel.updateValue('RAINING', true, true)
                             } else {
                                 channel.updateValue('RAINING', false, true)
                             }
 
                             channel.updateValue('WIND_SPEED', (observation.metric.windSpeed), true)
-                                //channel.updateValue('WIND_DIRECTION', observation.wind_degrees, true)
+                            channel.updateValue('WIND_DIRECTION', observation.winddir, true)
 
                             channel.updateValue('WIND_DIRECTION_RANGE', 0, true)
                             channel.updateValue('SUNSHINEDURATION', 0, true)


### PR DESCRIPTION
Hallo Thomas, 
mit diesem kleinen Fix konnte ich die Windrichtung übernehmen und RAINING wurde nach dem Regnen wieder auf FALSE gesetzt.  

Vielen Dank für Dein geniales Plugin!

Die WU API liefert mir aktuell folgende Antwort:

{
    "observations": [
        {
            "stationID": "IDORTMUN1",
            "obsTimeUtc": "2020-06-10T07:40:04Z",
            "obsTimeLocal": "2020-06-10 09:40:04",
            "neighborhood": "Stadtkrone Ost",
            "softwareType": "open2300 v1.10",
            "country": "DE",
            "solarRadiation": null,
            "lon": 7.525898,
            "realtimeFrequency": null,
            "epoch": 1591774804,
            "lat": 51.500465,
            "uv": null,
            "winddir": 338,
            "humidity": 90,
            "qcStatus": 1,
            "metric": {
                "temp": 12,
                "heatIndex": 12,
                "dewpt": 10,
                "windChill": 12,
                "windSpeed": 0,
                "windGust": null,
                "pressure": 1015.51,
                "precipRate": 0.00,
                "precipTotal": 0.00,
                "elev": 140
            }
        }
    ]
}